### PR TITLE
fix: use node 22.4 for npm failure workaround

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version: 22.4
       - name: Install dependencies
         run: npm ci
       - name: Run linter

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version: 22.4
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright Browsers


### PR DESCRIPTION
## Changes proposed
Use Node 22.4 to workaround this [issue](https://github.com/npm/cli/issues/7657)

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.
