### PR TITLE
ci: fix the changelog action version 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       # create release info and push it upstream
       - name: conventional Changelog Action
         id: changelog
-        uses: TriPSs/conventional-changelog-action@v3
+        uses: TriPSs/conventional-changelog-action@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version-file: "./package.json,./package-lock.json,./src/config/app.json"


### PR DESCRIPTION


## Changes proposed

- Bump **TriPSs/conventional-changelog-action** from v3 to v5 to let the error go away as old is deperecated

## Screenshots

![Screenshot 2024-07-19 at 9 09 07 PM](https://github.com/user-attachments/assets/f001cfd4-5a0e-4125-b53d-6a29830df676)
