### PR TITLE
feat: Moved GitHub Projects API usage from REST to GraphQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 > [!NOTE]
 > This project is sponsored by the Open Source project Flagsmith https://github.com/Flagsmith/flagsmith
-> 
+>
 > Feature flags have so many benefits, remote config, testing in production and so much more!
 
 # HealthCheck

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,13 @@
   "packages": {
     "": {
       "name": "healthcheck",
-      "version": "0.31.11",
+      "version": "0.36.0",
       "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.4.2",
         "@headlessui/react": "^2.1.5",
         "@heroicons/react": "^2.1.5",
+        "@octokit/graphql": "^8.1.1",
         "@octokit/rest": "^21.0.0",
         "@prisma/client": "^5.19.0",
         "@tailwindcss/aspect-ratio": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@auth/prisma-adapter": "^2.4.2",
     "@headlessui/react": "^2.1.5",
     "@heroicons/react": "^2.1.5",
+    "@octokit/graphql": "^8.1.1",
     "@octokit/rest": "^21.0.0",
     "@prisma/client": "^5.19.0",
     "@tailwindcss/aspect-ratio": "^0.4.2",

--- a/src/utils/checks/index.js
+++ b/src/utils/checks/index.js
@@ -46,7 +46,7 @@ export default function checks(data, ignoreChecks = []) {
     pullRequestTemplate(data.communityMetrics),
     codeOfConduct(data.communityMetrics),
     labels(data.labels),
-    // projects(data.repo, data.projects),
+    projects(data.repo, data.projects),
   ];
 
   const userChecks = filterIgnoredChecks(allChecks, ignoreChecks);

--- a/src/utils/checks/projects.js
+++ b/src/utils/checks/projects.js
@@ -11,14 +11,18 @@ export default function projects(repo, projectsData) {
     response.extra = "No action required.";
   }
 
-  if (repo.has_projects && projectsData.length > 0) {
+  const filteredProjectsData = projectsData.filter(
+    (project) => !project.closed,
+  ); // filter out closed projects
+
+  if (repo.has_projects && filteredProjectsData.length > 0) {
     response.status = "success";
     response.description =
       "You have project boards enabled and it is being used.";
     response.extra = "No action required.";
   }
 
-  if (repo.has_projects && projectsData.length === 0) {
+  if (repo.has_projects && filteredProjectsData.length === 0) {
     response.status = "error";
     response.description =
       "You have project boards enabled but it is not being used.";

--- a/src/utils/github/getProjectsApi.js
+++ b/src/utils/github/getProjectsApi.js
@@ -1,4 +1,4 @@
-import { Octokit } from "@octokit/rest";
+import { graphql } from "@octokit/graphql";
 import extractOwnerRepo from "./extractOwnerRepo";
 
 export default async function getProjectsApi(url, token) {
@@ -6,16 +6,38 @@ export default async function getProjectsApi(url, token) {
   const { owner, repo } = extractOwnerRepo(url);
 
   // get data from github api using user's API
-  const octokit = new Octokit({
-    auth: token,
+  const octokit = graphql.defaults({
+    headers: {
+      authorization: `token ${token}`,
+    },
   });
   let response;
   try {
-    response = await octokit.rest.projects.listForRepo({
-      owner,
-      repo,
-      state: "open",
-    });
+    response = await octokit(
+      `
+      query($owner: String!, $repo: String!) {
+        repository(owner: $owner, name: $repo) {
+          projectsV2(first: 10) {
+            nodes {
+              id
+              title
+              closed
+            }
+          }
+        }
+      }
+      `,
+      {
+        owner,
+        repo,
+      },
+    );
+    console.log(response);
+    console.error(response);
+    response = {
+      status: 200,
+      data: response.repository.projectsV2.nodes,
+    };
   } catch (e) {
     console.error(e);
     response = {
@@ -23,6 +45,7 @@ export default async function getProjectsApi(url, token) {
       data: [],
     };
   }
+  console.log(response);
 
   return response;
 }

--- a/src/utils/github/getProjectsApi.js
+++ b/src/utils/github/getProjectsApi.js
@@ -45,7 +45,6 @@ export default async function getProjectsApi(url, token) {
       data: [],
     };
   }
-  console.log(response);
 
   return response;
 }

--- a/src/utils/github/getProjectsApi.js
+++ b/src/utils/github/getProjectsApi.js
@@ -32,8 +32,6 @@ export default async function getProjectsApi(url, token) {
         repo,
       },
     );
-    console.log(response);
-    console.error(response);
     response = {
       status: 200,
       data: response.repository.projectsV2.nodes,


### PR DESCRIPTION
## Fixes Issue
Closes #249

## Changes proposed

This PR makes the following changes:
- Adds support for GitHub Projects V2 via GraphQL migrating from REST API

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## Screenshots

![Screenshot](https://github.com/user-attachments/assets/6c347bc4-9f9f-48c1-a539-25a10cba05ce)

[Screen Recording of my changes](https://github.com/user-attachments/assets/4b77587d-7922-4543-b095-45ea6cedfd7e)

## Note to reviewers

I could not find a way to fetch only `OPENED` projects and, I had to fetch `first 10`. Further, I requested only `id`, `title` and `closed`. I filtered those data in terms of `!closed` in the `ProjectsCheck` section. There is a rare case that all the 10 are closed. Let me know what I should do in that case. I have one option to try a `while` or `for` loop but that would soon reach API limit.